### PR TITLE
Add curl and jsonlite

### DIFF
--- a/R/revgeo.R
+++ b/R/revgeo.R
@@ -48,7 +48,7 @@ revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = N
   geocode_data <- list()
   geocode_frame <- data.frame()
   if (is.null(provider) || (provider %in% "photon")) {
-    url <- paste0("http://photon.komoot.de/reverse?lon=", 
+    url <- paste0("https://photon.komoot.de/reverse?lon=", 
                   longitude, "&lat=", latitude)
     for (i in url) {
       print(paste0("Getting geocode data from Photon: ", 

--- a/R/revgeo.R
+++ b/R/revgeo.R
@@ -54,7 +54,7 @@ revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = N
       print(paste0("Getting geocode data from Photon: ", 
                    i))
       data <- tryCatch(getURLAsynchronous(i), error = function(e) "Error")
-      returned_data <- tryCatch(fromJSON(data), error = function(e) "There was an issue retrieving an address from Photon.  Please check that your coordinates are correct and try again.")
+      returned_data <- tryCatch(jsonlite::fromJSON(data), error = function(e) "There was an issue retrieving an address from Photon.  Please check that your coordinates are correct and try again.")
       housenumber <- tryCatch(returned_data$features[[1]]$properties$housenumber, 
                               error = function(e) "House Number Not Found")
       street <- tryCatch(returned_data$features[[1]]$properties$street, 
@@ -141,7 +141,7 @@ revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = N
       print(paste0("Getting geocode data from Bing: ", 
                    i))
       data <- getURLAsynchronous(i)
-      returned_data <- tryCatch(fromJSON(data), error = function(e) "There was an issue retrieving an address from Bing.  Please check that your coordinates are coorect and try again.")
+      returned_data <- tryCatch(jsonlite::fromJSON(data), error = function(e) "There was an issue retrieving an address from Bing.  Please check that your coordinates are coorect and try again.")
       address_hash <- tryCatch(as.list(returned_data$resourceSets[[1]]$resources[[1]]$address), 
                                error = function(e) "House Number Not Found")
       street <- tryCatch(address_hash$addressLine, error = function(e) "House Number and Street Not Found")
@@ -212,7 +212,7 @@ revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = N
       print(paste0("Getting geocode data from Google: ", 
                    i))
       data <- getURLAsynchronous(i)
-      returned_data <- tryCatch(fromJSON(data), error = function(e) {
+      returned_data <- tryCatch(jsonlite::fromJSON(data), error = function(e) {
         message("There was an issue retrieving an address from Google Maps.  Please check that your coordinates are correct and try again.")
       })
       if ("status" %in% colnames(returned_data) == TRUE) {

--- a/R/revgeo.R
+++ b/R/revgeo.R
@@ -47,25 +47,53 @@ revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = N
   }
   geocode_data <- list()
   geocode_frame <- data.frame()
+  
+  async_download <- function(url) {
+    responses <- vector(mode = "list", length = length(url))
+    url_ids <- seq_along(url)
+    callback <- function(id){
+      function(response){
+        if (response$status_code == 200) {
+          print(paste0("Getting geocode data from Photon: ", response$url))
+        } else {
+          warning(paste0("Error encountered upon retrieving data from Photon: ", response$url))
+        }
+        responses[[id]] <<- response
+      }
+    }
+    errorhandle <- function(response) {
+      warning(response)
+    }
+    cbfuns <- lapply(url_ids, callback)
+    p <- curl::new_pool(total_con = 10, host_con = 5)
+    for (i in seq_along(url)) {
+      curl::curl_fetch_multi(url[i], done = cbfuns[[i]], fail = errorhandle, handle = curl::new_handle(failonerror = FALSE), pool = p)
+    }
+    curl::multi_run(pool = p)
+    
+    return(responses)
+  }
+  
+  
   if (is.null(provider) || (provider %in% "photon")) {
     url <- paste0("https://photon.komoot.de/reverse?lon=", 
                   longitude, "&lat=", latitude)
-    for (i in url) {
-      print(paste0("Getting geocode data from Photon: ", 
-                   i))
-      data <- tryCatch(getURLAsynchronous(i), error = function(e) "Error")
-      returned_data <- tryCatch(jsonlite::fromJSON(data), error = function(e) "There was an issue retrieving an address from Photon.  Please check that your coordinates are correct and try again.")
-      housenumber <- tryCatch(returned_data$features[[1]]$properties$housenumber, 
+    
+    responses <- async_download(url)
+    
+    for (response in responses) {
+      returned_data <- tryCatch(jsonlite::fromJSON(rawToChar(response$content)), error = function(e) "There was an issue retrieving an address from Photon.  Please check that your coordinates are correct and try again.")
+      housenumber <- tryCatch(returned_data$features$properties$housenumber, 
                               error = function(e) "House Number Not Found")
-      street <- tryCatch(returned_data$features[[1]]$properties$street, 
+      street <- tryCatch(returned_data$features$properties$street, 
                          error = function(e) "Street Not Found")
-      city <- tryCatch(returned_data$features[[1]]$properties$city, 
+      city <- tryCatch(returned_data$features$properties$city, 
                        error = function(e) "City Not Found")
-      zip <- tryCatch(returned_data$features[[1]]$properties$postcode, 
+      zip <- tryCatch(returned_data$features$properties$postcode, 
                       error = function(e) "Postcode Not Found")
-      state <- tryCatch(returned_data$features[[1]]$properties$state, 
+      state <- tryCatch(returned_data$features$properties$state, 
                         error = function(e) "State Not Found")
-      country <- tryCatch(returned_data$features[[1]]$properties$country, 
+      country <- tryCatch(returned_data$features$properties$country, 
                           error = function(e) "Country Not Found")
       if (is.null(housenumber)) {
         housenumber <- "House Number Not Found"
@@ -141,7 +169,7 @@ revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = N
       print(paste0("Getting geocode data from Bing: ", 
                    i))
       data <- getURLAsynchronous(i)
-      returned_data <- tryCatch(jsonlite::fromJSON(data), error = function(e) "There was an issue retrieving an address from Bing.  Please check that your coordinates are coorect and try again.")
+      returned_data <- tryCatch(fromJSON(data), error = function(e) "There was an issue retrieving an address from Bing.  Please check that your coordinates are coorect and try again.")
       address_hash <- tryCatch(as.list(returned_data$resourceSets[[1]]$resources[[1]]$address), 
                                error = function(e) "House Number Not Found")
       street <- tryCatch(address_hash$addressLine, error = function(e) "House Number and Street Not Found")
@@ -212,14 +240,14 @@ revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = N
       print(paste0("Getting geocode data from Google: ", 
                    i))
       data <- getURLAsynchronous(i)
-      returned_data <- tryCatch(jsonlite::fromJSON(data), error = function(e) {
+      returned_data <- tryCatch(fromJSON(data), error = function(e) {
         message("There was an issue retrieving an address from Google Maps.  Please check that your coordinates are correct and try again.")
       })
       if ("status" %in% colnames(returned_data) == TRUE) {
-          if(returned_data$status %in% "REQUEST_DENIED") {
-            print("There was an error accessing Google Maps.  Check your API key and try again.")
-            return()
-          }
+        if(returned_data$status %in% "REQUEST_DENIED") {
+          print("There was an error accessing Google Maps.  Check your API key and try again.")
+          return()
+        }
       }
       if(returned_data$status == "ZERO_RESULTS") {
         message <- "Google Maps could not find an address for your coordinates.  Please double check that they are accurate and try again."


### PR DESCRIPTION
First of all, thanks a lot for this great package!

When I tried to fetch a large number of locations from Photon through revgeo, the function would run without a problem for a couple of hours, but after around 6000 requests, the R session would freeze. This happened consistently both on Linux and on Windows.

Guessing that the issue might have to do with the RCurl package, I revised the revgeo code to rely on the curl package instead. Indeed, this resolved the freezing issue described above.

I also swapped the dependency on the RJSONIO package with the more modern jsonlite package. Besides being faster than RJSONIO, jsonlite also has better support for locales. For instance, an address parsed incorrectly by RJSONIO was correctly parsed with jsonlite:
- RJSONIO: "1 ReischekstraÃŸe, Linz, Upper Austria, 4020, Austria"
- jsonlite: "1 Reischekstraße, Linz, Upper Austria, 4020, Austria"

The above changes resulted in a 10% decrease in execution time for the reverse geocoding of 1000 coordinates on average over 10 tries.

For the moment, I have only made changes with respect to the Photon API. If you agree this is a sensible way to go, I am happy to implement the same solution for the other APIs.
