### PR TITLE
-new Photon url

### DIFF
--- a/R/revgeo.R
+++ b/R/revgeo.R
@@ -100,7 +100,7 @@ revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = N
   
   
   if (is.null(provider) || (provider %in% "photon")) {
-    url <- paste0("https://photon.komoot.de/reverse?lon=", 
+    url <- paste0("https://photon.komoot.io/reverse?lon=", 
                   longitude, "&lat=", latitude)
     
     responses <- async_download(url, provider)


### PR DESCRIPTION
-photon.de is now redirected to photon.io (301), which prevents `revgeo` from getting data. This commit simply updates the base url