### PR TITLE
Language setting option for Photon

### DIFF
--- a/R/revgeo.R
+++ b/R/revgeo.R
@@ -31,7 +31,7 @@
 #' @import jsonlite
 #' @export
 
-revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = NULL, item = NULL) 
+revgeo <- function (longitude, latitude, language = "en", provider = NULL, API = NULL, output = NULL, item = NULL) 
 {
   if (missing(provider)) {
     provider <- NULL
@@ -100,7 +100,7 @@ revgeo <- function (longitude, latitude, provider = NULL, API = NULL, output = N
   
   
   if (is.null(provider) || (provider %in% "photon")) {
-    url <- paste0("https://photon.komoot.io/reverse?lon=", 
+    url <- paste0("https://photon.komoot.io/reverse?lang=", language, "&lon=", 
                   longitude, "&lat=", latitude)
     
     responses <- async_download(url, provider)


### PR DESCRIPTION
To avoid the inconsistent language scheme photon gives when no language is specified, I propose adding a new parameter to allow the user to specify a language (with the default being English).

If we wish to allow users to keep using unspecified language queries, we will have to change this further, but I suspect that is a very rare use case.